### PR TITLE
List more specific rule

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -30,9 +30,20 @@ const validCss = `@import url(x.css);
   font-size: 16px;
   text-decoration: underline;
   white-space: nowrap;
-  transition: all 0.2s ease-in-out;
   opacity: 0.5;
+  transition: all 0.2s ease-in-out;
   user-select: none;
+}
+
+.selector-4 {
+  display: flex;
+  justify-content: center;
+  background-image: linear-gradient(0deg, #fafafa, #fafafa);
+  background-position-x: right;
+  background-repeat: no-repeat;
+  background-size: 25% 100%;
+  opacity: 1;
+  transition: opacity 0.5s;
 }
 
 .selector-a,
@@ -67,6 +78,10 @@ const validCss = `@import url(x.css);
     height: 10rem;
     margin: 10px;
     margin-bottom: 5px;
+    box-shadow:
+      0 1px 1px #000,
+      0 1px 0 #fff,
+      2px 2px 1px 1px #ccc inset;
     background-image:
       repeating-linear-gradient(
         -45deg,
@@ -74,10 +89,6 @@ const validCss = `@import url(x.css);
         #fff 25px,
         rgba(255, 255, 255, 1) 50px
       );
-    box-shadow:
-      0 1px 1px #000,
-      0 1px 0 #fff,
-      2px 2px 1px 1px #ccc inset;
   }
 
   /* Flush nested single line comment */

--- a/index.js
+++ b/index.js
@@ -19,33 +19,74 @@ module.exports = {
         'overflow-x',
         'overflow-y',
         'box-sizing',
+
         'width',
         'max-width',
         'min-width',
+
         'height',
         'max-height',
         'min-height',
+
         'margin',
         'margin-top',
         'margin-right',
         'margin-bottom',
         'margin-left',
+
         'padding',
         'padding-top',
         'padding-right',
         'padding-bottom',
         'padding-left',
+
         'border',
         'border-top',
         'border-right',
         'border-bottom',
         'border-left',
+
+        'border-width',
+        'border-top-width',
+        'border-right-width',
+        'border-bottom-width',
+        'border-left-width',
+
+        'border-style',
+        'border-top-style',
+        'border-right-style',
+        'border-bottom-style',
+        'border-left-style',
+
+        'border-color',
+        'border-top-color',
+        'border-right-color',
+        'border-bottom-color',
+        'border-left-color',
+
+        'border-collapse',
+        'border-spacing',
+
         'border-radius',
         'border-top-right-radius',
         'border-bottom-right-radius',
         'border-bottom-left-radius',
         'border-top-left-radius',
+
+        'border-image',
+        'border-image-outset',
+        'border-image-repeat',
+        'border-image-slice',
+        'border-image-source',
+        'border-image-width',
+
+        'box-shadow',
+
         'outline',
+        'outline-color',
+        'outline-offset',
+        'outline-style',
+        'outline-width',
 
         /* Flex Container(Parent) */
         'flex-flow',
@@ -63,35 +104,54 @@ module.exports = {
         'order',
         'align-self',
 
-        /* Color */
+        /* Background */
         'background',
+        'background-attachment',
+        'background-clip',
+        'background-color',
         'background-image',
-        'color',
-        'box-shadow',
+        'background-origin',
+        'background-position',
+        'background-position-x',
+        'background-position-y',
+        'background-repeat',
+        'background-size',
 
         /* Text */
+        'color',
         'font-family',
         'font-size',
+        'letter-spacing',
         'line-height',
+        'overflow-wrap',
         'text-align',
         'text-decoration',
+        'text-decoration-color',
+        'text-decoration-line',
+        'text-indent',
+        'text-overflow',
         'text-shadow',
+        'text-transform',
         'vertical-align',
         'white-space',
-
-        /* Effect */
-        'transition',
-        'transform',
-        'opacity',
-        'visibility',
-        'appearance',
-        'user-select',
-
-        /* Other */
         'word-break',
         'word-wrap',
-        'content',
+
+        /* Effect */
+        'opacity',
+        'visibility',
+        'transform',
+        'transition',
+        'transition-delay',
+        'transition-duration',
+        'transition-property',
+        'transition-timing-function',
+
+        /* Misc, in alphabetical order */
+        'appearance',
         'cursor',
+        'content',
+        'user-select',
       ],
       { unspecified: 'bottomAlphabetical' },
     ],


### PR DESCRIPTION
1. `transform` & `transition` should be ordered after `opacity` & `visibility`
Because there are some rule may look like `transition: opacity .15s ease-in-out;`

2. list more `background`, `border`, `outline` rules
Because there are some real case using these rules: https://github.com/bottenderjs/bottenderjs.github.io/blob/source/src/templates/withSidebar.js#L73-L81

3. `word-break` & `word-wrap` put in TEXT group. // breaking?

4. `appearance` & `user-select` are not so common, so put them in MISC group.

RFC @xxhomey19 @jigsawye about `3.` & `4.`