### PR TITLE
fix: ignore dummyValue to fix usage with styled-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - extends: [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard)
 - plugins: [stylelint-order](https://github.com/hudochenkov/stylelint-order)
 - `order/properties-order`: Follow [css-property-sort-order-smacss](https://github.com/cahamilton/css-property-sort-order-smacss/blob/master/index.js)
+- `value-keyword-case`: ignore `dummyValue` for `styled-component` usage
 
 [npm-image]: https://badge.fury.io/js/stylelint-config-yoctol.svg
 [npm-url]: https://www.npmjs.com/package/stylelint-config-yoctol

--- a/src/index.js
+++ b/src/index.js
@@ -16,5 +16,6 @@ module.exports = {
       ],
       { unspecified: 'bottomAlphabetical' },
     ],
+    'value-keyword-case': ['lower', { ignoreKeywords: ['dummyValue'] }],
   },
 };


### PR DESCRIPTION
因為 https://github.com/styled-components/stylelint-processor-styled-components 這個會在處理那種 `${p => p.prop}` 的時候塞 dummyValue 進去於是會跟 stylelint-config-standard v20 的 fix 衝突，就 ignore